### PR TITLE
Remove oraclejdk7 from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ notifications:
   email: false
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
   - openjdk6


### PR DESCRIPTION
oraclejdk7 is no longer supported by Oracle and openjdk7 is pretty
similar.