### PR TITLE
Implement customizable landing pages after login / use "127.0.0.1" instead of "localhost"

### DIFF
--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -76,5 +76,10 @@
       <groupId>org.mortbay.jetty</groupId>
       <artifactId>jetty</artifactId>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -79,6 +79,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>4.8.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
+++ b/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
@@ -45,6 +45,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 public final class LocalServerReceiver implements VerificationCodeReceiver {
 
+  private static final String LOCALHOST = "127.0.0.1";
+
   private static final String CALLBACK_PATH = "/Callback";
 
   /** Server or {@code null} before {@link #getRedirectUri()}. */
@@ -88,7 +90,7 @@ public final class LocalServerReceiver implements VerificationCodeReceiver {
    * </p>
    */
   public LocalServerReceiver() {
-    this("127.0.0.1", -1);
+    this(LOCALHOST, -1);
   }
 
   public LocalServerReceiver(String successLandingPageUrl, String failureLandingPageUrl) {

--- a/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
+++ b/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
@@ -81,7 +81,7 @@ public final class LocalServerReceiver implements VerificationCodeReceiver {
   private String failureLandingPageUrl;
 
   /**
-   * Constructor that starts the server on {@code "127.0.0.1"} selects an unused port.
+   * Constructor that starts the server on {@code "127.0.0.1"} and an unused port.
    *
    * <p>
    * Use {@link Builder} if you need to specify any of the optional parameters.

--- a/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
+++ b/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
@@ -81,7 +81,7 @@ public final class LocalServerReceiver implements VerificationCodeReceiver {
   private String failureLandingPageUrl;
 
   /**
-   * Constructor that starts the server on {@code "localhost"} selects an unused port.
+   * Constructor that starts the server on {@code "127.0.0.1"} selects an unused port.
    *
    * <p>
    * Use {@link Builder} if you need to specify any of the optional parameters.
@@ -188,7 +188,7 @@ public final class LocalServerReceiver implements VerificationCodeReceiver {
   public static final class Builder {
 
     /** Host name to use. */
-    private String host = "localhost";
+    private String host = "127.0.0.1";
 
     /** Port to use or {@code -1} to select an unused port. */
     private int port = -1;

--- a/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
+++ b/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
@@ -88,11 +88,11 @@ public final class LocalServerReceiver implements VerificationCodeReceiver {
    * </p>
    */
   public LocalServerReceiver() {
-    this("localhost", -1);
+    this("127.0.0.1", -1);
   }
 
   public LocalServerReceiver(String successLandingPageUrl, String failureLandingPageUrl) {
-    this("localhost", -1);
+    this();
     this.successLandingPageUrl = successLandingPageUrl;
     this.failureLandingPageUrl = failureLandingPageUrl;
   }

--- a/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
+++ b/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
@@ -83,7 +83,7 @@ public final class LocalServerReceiver implements VerificationCodeReceiver {
   private String failureLandingPageUrl;
 
   /**
-   * Constructor that starts the server on {@code "127.0.0.1"} and an unused port.
+   * Constructor that starts the server on {@link #LOCALHOST} and an unused port.
    *
    * <p>
    * Use {@link Builder} if you need to specify any of the optional parameters.
@@ -190,7 +190,7 @@ public final class LocalServerReceiver implements VerificationCodeReceiver {
   public static final class Builder {
 
     /** Host name to use. */
-    private String host = "127.0.0.1";
+    private String host = LOCALHOST;
 
     /** Port to use or {@code -1} to select an unused port. */
     private int port = -1;

--- a/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
+++ b/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
@@ -90,13 +90,7 @@ public final class LocalServerReceiver implements VerificationCodeReceiver {
    * </p>
    */
   public LocalServerReceiver() {
-    this(LOCALHOST, -1);
-  }
-
-  public LocalServerReceiver(String successLandingPageUrl, String failureLandingPageUrl) {
-    this();
-    this.successLandingPageUrl = successLandingPageUrl;
-    this.failureLandingPageUrl = failureLandingPageUrl;
+    this(LOCALHOST, -1, null, null);
   }
 
   /**
@@ -105,9 +99,12 @@ public final class LocalServerReceiver implements VerificationCodeReceiver {
    * @param host Host name to use
    * @param port Port to use or {@code -1} to select an unused port
    */
-  LocalServerReceiver(String host, int port) {
+  LocalServerReceiver(String host, int port,
+                      String successLandingPageUrl, String failureLandingPageUrl) {
     this.host = host;
     this.port = port;
+    this.successLandingPageUrl = successLandingPageUrl;
+    this.failureLandingPageUrl = failureLandingPageUrl;
   }
 
   @Override
@@ -195,9 +192,12 @@ public final class LocalServerReceiver implements VerificationCodeReceiver {
     /** Port to use or {@code -1} to select an unused port. */
     private int port = -1;
 
+    private String successLandingPageUrl;
+    private String failureLandingPageUrl;
+
     /** Builds the {@link LocalServerReceiver}. */
     public LocalServerReceiver build() {
-      return new LocalServerReceiver(host, port);
+      return new LocalServerReceiver(host, port, successLandingPageUrl, failureLandingPageUrl);
     }
 
     /** Returns the host name to use. */
@@ -219,6 +219,12 @@ public final class LocalServerReceiver implements VerificationCodeReceiver {
     /** Sets the port to use or {@code -1} to select an unused port. */
     public Builder setPort(int port) {
       this.port = port;
+      return this;
+    }
+
+    public Builder setLandingPages(String successLandingPageUrl, String failureLandingPageUrl) {
+      this.successLandingPageUrl = successLandingPageUrl;
+      this.failureLandingPageUrl = failureLandingPageUrl;
       return this;
     }
   }

--- a/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
+++ b/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
@@ -45,7 +45,7 @@ import javax.servlet.http.HttpServletResponse;
  */
 public final class LocalServerReceiver implements VerificationCodeReceiver {
 
-  private static final String LOCALHOST = "127.0.0.1";
+  private static final String LOCALHOST = "localhost";
 
   private static final String CALLBACK_PATH = "/Callback";
 

--- a/google-oauth-client-jetty/src/test/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiverTest.java
+++ b/google-oauth-client-jetty/src/test/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiverTest.java
@@ -29,11 +29,6 @@ public class LocalServerReceiverTest {
   private String redirectedLandingPageUrl;
 
   @Test
-  public void testNumericLocalhost() {
-    Assert.assertEquals("127.0.0.1", new LocalServerReceiver().getHost());
-  }
-
-  @Test
   public void testSuccessLandingPage() throws IOException, InterruptedException {
     String successLandingPageUrl = "https://www.example.com/my-success-landing-page";
     LocalServerReceiver receiver = new LocalServerReceiver(successLandingPageUrl, null);

--- a/google-oauth-client-jetty/src/test/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiverTest.java
+++ b/google-oauth-client-jetty/src/test/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiverTest.java
@@ -18,7 +18,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;

--- a/google-oauth-client-jetty/src/test/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiverTest.java
+++ b/google-oauth-client-jetty/src/test/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiverTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.api.client.extensions.jetty.auth.oauth2;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class LocalServerReceiverTest {
+
+  private int responseCode;
+  private StringBuilder responseOutput = new StringBuilder();
+  private String redirectedLandingPageUrl;
+
+  @Test
+  public void testSuccessLandingPage() throws IOException, InterruptedException {
+    String successLandingPageUrl = "https://www.example.com/my-success-landing-page";
+    LocalServerReceiver receiver = new LocalServerReceiver(successLandingPageUrl, null);
+
+    try {
+      sendSuccessLoginResult(receiver.getRedirectUri());
+      verifyRedirectedLandingPageUrl(successLandingPageUrl);
+    } finally {
+      receiver.stop();
+    }
+  }
+
+  @Test
+  public void testFailureLandingPage() throws IOException {
+    String failureLandingPageUrl = "https://www.example.com/my-failure-landing-page";
+    LocalServerReceiver receiver = new LocalServerReceiver(null, failureLandingPageUrl);
+
+    try {
+      sendFailureLoginResult(receiver.getRedirectUri());
+      verifyRedirectedLandingPageUrl(failureLandingPageUrl);
+    } finally {
+      receiver.stop();
+    }
+  }
+
+  @Test
+  public void testDefaultSuccessLandingPage() throws IOException {
+    LocalServerReceiver receiver = new LocalServerReceiver(null, null);
+
+    try {
+      sendSuccessLoginResult(receiver.getRedirectUri());
+      verifyDefaultLandingPage();
+    } finally {
+      receiver.stop();
+    }
+  }
+
+  @Test
+  public void testDefaultFailureLandingPage() throws IOException {
+    LocalServerReceiver receiver = new LocalServerReceiver(null, null);
+
+    try {
+      sendFailureLoginResult(receiver.getRedirectUri());
+      verifyDefaultLandingPage();
+    } finally {
+      receiver.stop();
+    }
+  }
+
+  private void verifyRedirectedLandingPageUrl(String landingPageUrlMatch) {
+    Assert.assertEquals(302, responseCode);
+    Assert.assertEquals(landingPageUrlMatch, redirectedLandingPageUrl);
+    Assert.assertTrue(responseOutput.toString().isEmpty());
+  }
+
+  private void verifyDefaultLandingPage() {
+    Assert.assertEquals(200, responseCode);
+    Assert.assertNull(redirectedLandingPageUrl);
+    Assert.assertTrue(responseOutput.toString().contains("<html>"));
+    Assert.assertTrue(responseOutput.toString().contains("</html>"));
+  }
+
+  private void sendSuccessLoginResult(String serverEndpoint) throws IOException {
+    sendLoginResult(serverEndpoint, "?code=some-authorization-code");
+  }
+
+  private void sendFailureLoginResult(String serverEndpoint) throws IOException {
+    sendLoginResult(serverEndpoint, "?error=some-error");
+  }
+
+  private void sendLoginResult(final String serverEndpoint, final String parameters)
+      throws IOException {
+    HttpURLConnection connection = null;
+
+    try {
+      URL url = new URL(serverEndpoint + parameters);
+      connection = (HttpURLConnection) url.openConnection();
+      connection.setConnectTimeout(2000 /* ms */);
+      connection.setReadTimeout(2000 /* ms */);
+      responseCode = connection.getResponseCode();
+      redirectedLandingPageUrl = connection.getHeaderField("Location");
+
+      InputStreamReader reader = new InputStreamReader(connection.getInputStream(), "UTF-8");
+      for (int ch = reader.read(); ch != -1; ch = reader.read()) {
+        responseOutput.append((char) ch);
+      }
+    } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
+    }
+  }
+}

--- a/google-oauth-client-jetty/src/test/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiverTest.java
+++ b/google-oauth-client-jetty/src/test/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiverTest.java
@@ -30,6 +30,11 @@ public class LocalServerReceiverTest {
   private String redirectedLandingPageUrl;
 
   @Test
+  public void testNumericLocalhost() {
+    Assert.assertEquals("127.0.0.1", new LocalServerReceiver().getHost());
+  }
+
+  @Test
   public void testSuccessLandingPage() throws IOException, InterruptedException {
     String successLandingPageUrl = "https://www.example.com/my-success-landing-page";
     LocalServerReceiver receiver = new LocalServerReceiver(successLandingPageUrl, null);

--- a/google-oauth-client-jetty/src/test/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiverTest.java
+++ b/google-oauth-client-jetty/src/test/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiverTest.java
@@ -31,7 +31,8 @@ public class LocalServerReceiverTest {
   @Test
   public void testSuccessLandingPage() throws IOException, InterruptedException {
     String successLandingPageUrl = "https://www.example.com/my-success-landing-page";
-    LocalServerReceiver receiver = new LocalServerReceiver(successLandingPageUrl, null);
+    LocalServerReceiver receiver =
+        new LocalServerReceiver.Builder().setLandingPages(successLandingPageUrl, null).build();
 
     try {
       sendSuccessLoginResult(receiver.getRedirectUri());
@@ -44,7 +45,8 @@ public class LocalServerReceiverTest {
   @Test
   public void testFailureLandingPage() throws IOException {
     String failureLandingPageUrl = "https://www.example.com/my-failure-landing-page";
-    LocalServerReceiver receiver = new LocalServerReceiver(null, failureLandingPageUrl);
+    LocalServerReceiver receiver =
+        new LocalServerReceiver.Builder().setLandingPages(null, failureLandingPageUrl).build();
 
     try {
       sendFailureLoginResult(receiver.getRedirectUri());
@@ -56,7 +58,8 @@ public class LocalServerReceiverTest {
 
   @Test
   public void testDefaultSuccessLandingPage() throws IOException {
-    LocalServerReceiver receiver = new LocalServerReceiver(null, null);
+    LocalServerReceiver receiver =
+        new LocalServerReceiver.Builder().setLandingPages(null, null).build();
 
     try {
       sendSuccessLoginResult(receiver.getRedirectUri());
@@ -68,7 +71,8 @@ public class LocalServerReceiverTest {
 
   @Test
   public void testDefaultFailureLandingPage() throws IOException {
-    LocalServerReceiver receiver = new LocalServerReceiver(null, null);
+    LocalServerReceiver receiver =
+        new LocalServerReceiver.Builder().setLandingPages(null, null).build();
 
     try {
       sendFailureLoginResult(receiver.getRedirectUri());


### PR DESCRIPTION
Fixes #128.

The change in `LocalServerReceiver` is actually very small. Added several unit tests, which verify actual responses of the local server.

PTAL.