### PR TITLE
Add OSGi Metadata

### DIFF
--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -36,7 +36,6 @@
         <executions>
           <execution>
             <id>jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -48,7 +47,6 @@
         <executions>
           <execution>
             <id>source-jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>

--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -24,26 +24,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>com.google.oauth-client-appengine</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
-          </instructions>
-        </configuration>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
@@ -56,7 +36,6 @@
         <executions>
           <execution>
             <id>jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -68,7 +47,6 @@
         <executions>
           <execution>
             <id>source-jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -102,6 +80,26 @@
             <version>1.0</version>
           </signature>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client-appengine</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -82,6 +82,26 @@
           </signature>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client-appengine</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>2.5.4</version>
         <configuration>
           <instructions>
             <Bundle-SymbolicName>com.google.oauth-client-appengine</Bundle-SymbolicName>

--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -24,6 +24,26 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client-appengine</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
@@ -36,6 +56,7 @@
         <executions>
           <execution>
             <id>jar</id>
+            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -47,6 +68,7 @@
         <executions>
           <execution>
             <id>source-jar</id>
+            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -80,26 +102,6 @@
             <version>1.0</version>
           </signature>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>com.google.oauth-client-appengine</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
-          </instructions>
-        </configuration>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -30,6 +30,7 @@
             <manifest>
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
         <executions>

--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -33,14 +33,6 @@
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
-        <executions>
-          <execution>
-            <id>jar</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/google-oauth-client-assembly/pom.xml
+++ b/google-oauth-client-assembly/pom.xml
@@ -90,6 +90,26 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client-assembly</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/google-oauth-client-assembly/pom.xml
+++ b/google-oauth-client-assembly/pom.xml
@@ -90,26 +90,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>com.google.oauth-client-assembly</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
-          </instructions>
-        </configuration>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -65,6 +65,26 @@
           </signature>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client-java6</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -29,6 +29,7 @@
             <manifest>
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
         <executions>

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -23,6 +23,26 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client-java6</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
@@ -35,6 +55,7 @@
         <executions>
           <execution>
             <id>jar</id>
+            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -46,6 +67,7 @@
         <executions>
           <execution>
             <id>source-jar</id>
+            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -63,26 +85,6 @@
             <version>1.0</version>
           </signature>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>com.google.oauth-client-java6</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
-          </instructions>
-        </configuration>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -23,26 +23,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>com.google.oauth-client-java6</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
-          </instructions>
-        </configuration>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
@@ -55,7 +35,6 @@
         <executions>
           <execution>
             <id>jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -67,7 +46,6 @@
         <executions>
           <execution>
             <id>source-jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -85,6 +63,26 @@
             <version>1.0</version>
           </signature>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client-java6</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -67,7 +67,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>2.5.4</version>
         <configuration>
           <instructions>
             <Bundle-SymbolicName>com.google.oauth-client-java6</Bundle-SymbolicName>

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -35,7 +35,6 @@
         <executions>
           <execution>
             <id>jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -47,7 +46,6 @@
         <executions>
           <execution>
             <id>source-jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>

--- a/google-oauth-client-java6/pom.xml
+++ b/google-oauth-client-java6/pom.xml
@@ -32,14 +32,6 @@
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
-        <executions>
-          <execution>
-            <id>jar</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -29,6 +29,7 @@
             <manifest>
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
         <executions>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -65,6 +65,26 @@
           </signature>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client-jetty</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -23,26 +23,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>com.google.oauth-client-jetty</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
-          </instructions>
-        </configuration>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
@@ -55,7 +35,6 @@
         <executions>
           <execution>
             <id>jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -67,7 +46,6 @@
         <executions>
           <execution>
             <id>source-jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -85,6 +63,26 @@
             <version>1.0</version>
           </signature>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client-jetty</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -23,6 +23,26 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client-jetty</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
@@ -35,6 +55,7 @@
         <executions>
           <execution>
             <id>jar</id>
+            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -46,6 +67,7 @@
         <executions>
           <execution>
             <id>source-jar</id>
+            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -63,26 +85,6 @@
             <version>1.0</version>
           </signature>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>com.google.oauth-client-jetty</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
-          </instructions>
-        </configuration>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -67,7 +67,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>2.5.4</version>
         <configuration>
           <instructions>
             <Bundle-SymbolicName>com.google.oauth-client-jetty</Bundle-SymbolicName>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -35,7 +35,6 @@
         <executions>
           <execution>
             <id>jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -47,7 +46,6 @@
         <executions>
           <execution>
             <id>source-jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>

--- a/google-oauth-client-jetty/pom.xml
+++ b/google-oauth-client-jetty/pom.xml
@@ -32,14 +32,6 @@
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
-        <executions>
-          <execution>
-            <id>jar</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -24,6 +24,26 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client-servlet</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
@@ -36,6 +56,7 @@
         <executions>
           <execution>
             <id>jar</id>
+            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -47,6 +68,7 @@
         <executions>
           <execution>
             <id>source-jar</id>
+            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -65,26 +87,6 @@
             <phase>process-classes</phase>
             <goals>
               <goal>enhance</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>com.google.oauth-client-servlet</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
-          </instructions>
-        </configuration>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
             </goals>
           </execution>
         </executions>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -36,7 +36,6 @@
         <executions>
           <execution>
             <id>jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -48,7 +47,6 @@
         <executions>
           <execution>
             <id>source-jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -70,6 +70,26 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client-servlet</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -72,7 +72,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>2.5.4</version>
         <configuration>
           <instructions>
             <Bundle-SymbolicName>com.google.oauth-client-servlet</Bundle-SymbolicName>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -30,6 +30,7 @@
             <manifest>
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
         <executions>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -33,14 +33,6 @@
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
-        <executions>
-          <execution>
-            <id>jar</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -24,26 +24,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>com.google.oauth-client-servlet</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
-          </instructions>
-        </configuration>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
@@ -56,7 +36,6 @@
         <executions>
           <execution>
             <id>jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -68,7 +47,6 @@
         <executions>
           <execution>
             <id>source-jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -87,6 +65,26 @@
             <phase>process-classes</phase>
             <goals>
               <goal>enhance</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client-servlet</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
             </goals>
           </execution>
         </executions>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -37,14 +37,6 @@
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
-        <executions>
-          <execution>
-            <id>jar</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -58,6 +58,26 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -60,7 +60,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>2.5.4</version>
         <configuration>
           <instructions>
             <Bundle-SymbolicName>com.google.oauth-client</Bundle-SymbolicName>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -34,6 +34,7 @@
             <manifest>
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
         <executions>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -40,7 +40,6 @@
         <executions>
           <execution>
             <id>jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -52,7 +51,6 @@
         <executions>
           <execution>
             <id>source-jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -28,36 +28,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifest>
-              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-            </manifest>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-          </archive>
-        </configuration>
-        <executions>
-          <execution>
-            <id>jar</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>source-jar</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <version>3.2.0</version>
@@ -70,9 +40,41 @@
         <executions>
           <execution>
             <id>bundle-manifest</id>
-            <phase>process-classes</phase>
+            <phase>compile</phase>
             <goals>
               <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+        <executions>
+          <execution>
+            <id>jar</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>source-jar</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>jar</goal>
             </goals>
           </execution>
         </executions>

--- a/google-oauth-client/pom.xml
+++ b/google-oauth-client/pom.xml
@@ -28,26 +28,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>com.google.oauth-client</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
-          </instructions>
-        </configuration>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
@@ -60,7 +40,6 @@
         <executions>
           <execution>
             <id>jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -72,9 +51,28 @@
         <executions>
           <execution>
             <id>source-jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.google.oauth-client</Bundle-SymbolicName>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Fixes #125.

Adding metadata to the following modules:
`google-oauth-client`
`google-oauth-client-java6`
`google-oauth-client-servlet`
`google-oauth-client-appengine`
`google-oauth-client-jetty`

I skipped the following module, as it seems to be a special module for assembling a zip:
`google-oauth-client-assembly`
