### PR TITLE
Allow credential without explicit expire time

### DIFF
--- a/google-oauth-client-java6/src/main/java/com/google/api/client/extensions/java6/auth/oauth2/AuthorizationCodeInstalledApp.java
+++ b/google-oauth-client-java6/src/main/java/com/google/api/client/extensions/java6/auth/oauth2/AuthorizationCodeInstalledApp.java
@@ -69,7 +69,9 @@ public class AuthorizationCodeInstalledApp {
     try {
       Credential credential = flow.loadCredential(userId);
       if (credential != null
-          && (credential.getRefreshToken() != null || credential.getExpiresInSeconds() > 60)) {
+          && (credential.getRefreshToken() != null || 
+              credential.getExpiresInSeconds() == null || 
+              credential.getExpiresInSeconds() > 60)) {
         return credential;
       }
       // open in browser


### PR DESCRIPTION
Certain sites provide an access token without an expiration. Currently this causes a NullPointerException. This change is to allow valid credentials that don't have an expiry.