### PR TITLE
Add scope provided to pom.xml

### DIFF
--- a/google-oauth-client-appengine/pom.xml
+++ b/google-oauth-client-appengine/pom.xml
@@ -121,6 +121,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/google-oauth-client-servlet/pom.xml
+++ b/google-oauth-client-servlet/pom.xml
@@ -100,6 +100,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>javax.jdo</groupId>


### PR DESCRIPTION
1. Don’t include the API as servlet containers will need it.

It looks like it may be needed for client-jetty, but that seems to
target a very old version of jetty.