### PR TITLE
Use caller-provided callback path for callback handler

### DIFF
--- a/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
+++ b/google-oauth-client-jetty/src/main/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiver.java
@@ -256,7 +256,7 @@ public final class LocalServerReceiver implements VerificationCodeReceiver {
     public void handle(
         String target, HttpServletRequest request, HttpServletResponse response, int dispatch)
         throws IOException {
-      if (!CALLBACK_PATH.equals(target)) {
+      if (!callbackPath.equals(target)) {
         return;
       }
 

--- a/google-oauth-client-jetty/src/test/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiverTest.java
+++ b/google-oauth-client-jetty/src/test/java/com/google/api/client/extensions/jetty/auth/oauth2/LocalServerReceiverTest.java
@@ -58,10 +58,22 @@ public class LocalServerReceiverTest {
     final String CALLBACK_PATH = "/Some/other/path";
     LocalServerReceiver receiver = new LocalServerReceiver("localhost", -1, CALLBACK_PATH, null, null);
 
+    HttpURLConnection connection = null;
     try {
       String localEndpoint = receiver.getRedirectUri();
       assertEquals("http://localhost:" + receiver.getPort() + CALLBACK_PATH, localEndpoint);
+
+      // Check that callback handler is accessible
+      URL url = new URL(localEndpoint);
+      connection = (HttpURLConnection) url.openConnection();
+      connection.setConnectTimeout(2000 /* ms */);
+      connection.setReadTimeout(2000 /* ms */);
+      int responseCode = connection.getResponseCode();
+      assertEquals(200, responseCode);
     } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
       receiver.stop();
     }
   }


### PR DESCRIPTION
Currently the LocalServerReceiver callback handler is checking the target against the default CALLBACK_PATH ("/Callback") instead of the user-provided callback path.

This fixes the issue and adds a test to check that a custom callback path is accessible.