### PR TITLE
Hotfix/abs.issue

### DIFF
--- a/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthParameters.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthParameters.java
@@ -117,7 +117,7 @@ public final class OAuthParameters implements HttpExecuteInterceptor, HttpReques
    * the {@link #nonce} field.
    */
   public void computeNonce() {
-    nonce = Long.toHexString(Math.abs(RANDOM.nextLong()));
+      nonce = Long.toHexString(Math.abs(RANDOM.nextLong() >>> 1));
   }
 
   /**

--- a/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthParameters.java
+++ b/google-oauth-client/src/main/java/com/google/api/client/auth/oauth/OAuthParameters.java
@@ -117,7 +117,7 @@ public final class OAuthParameters implements HttpExecuteInterceptor, HttpReques
    * the {@link #nonce} field.
    */
   public void computeNonce() {
-      nonce = Long.toHexString(Math.abs(RANDOM.nextLong() >>> 1));
+      nonce = Long.toHexString(RANDOM.nextLong() >>> 1);
   }
 
   /**


### PR DESCRIPTION
Pull Request for Issue #142 

Apologies for the double commit.

If you'd rather I re-submit as a single commit please let me know.

Contents of issue #142 below:

The computeNonce() suffers from a logical error. As per the method comments, the method "Computes a nonce based on the hex string of a random non-negative long"

The method is as follows:
nonce = Long.toHexString(Math.abs(RANDOM.nextLong()));

RANDOM is defined as a SecureRandom object, and the SecureRandom.nextLong() calls Random.nextLong() which can return positive and negative numbers.

As per squid:S267 Long.MIN_VALUE could be returned from Random.nextLong(). Calling Math.abs on values returned from these methods is ill-advised.

The problem is that Random.nextLong() can return Long.MIN_VALUE. Due to two's complement representation, the absolute value of Long.MIN_VALUE is itself, the most negative possible long.

My solution is to remove the Math.abs() call and do some shifting, so that we are dealing with positive numbers only - as per the comments of the method.

nonce = Long.toHexString(RANDOM.nextLong() >>> 1);

Apologies for the double commit for this fix.