### PR TITLE
Browser handler

### DIFF
--- a/google-oauth-client-java6/src/main/java/com/google/api/client/extensions/java6/auth/oauth2/AuthorizationCodeInstalledApp.java
+++ b/google-oauth-client-java6/src/main/java/com/google/api/client/extensions/java6/auth/oauth2/AuthorizationCodeInstalledApp.java
@@ -51,9 +51,9 @@ public class AuthorizationCodeInstalledApp {
     /**
      *
      * @param url url to browse
-     * @throws Exception
+     * @throws IOException
      */
-    public void browse(String url) throws Exception;
+    public void browse(String url) throws IOException;
   }
 
   /**
@@ -64,7 +64,7 @@ public class AuthorizationCodeInstalledApp {
    */
   public static class DefaultBrowser implements Browser{
 
-    public void browse(String url) throws Exception {
+    public void browse(String url) throws IOException {
       AuthorizationCodeInstalledApp.browse(url);
     }
 
@@ -154,13 +154,7 @@ public class AuthorizationCodeInstalledApp {
   protected void onAuthorization(AuthorizationCodeRequestUrl authorizationUrl) throws IOException {
     String url = authorizationUrl.build();
     Preconditions.checkNotNull(url);
-    System.out.println("Please open the following address in your browser:");
-    System.out.println("  " + url);
-    try {
-      browser.browse(url);
-    } catch (Exception e) {
-      LOGGER.log(Level.WARNING, "Unable to open browser", e);
-    }
+    browser.browse(url);
   }
 
   /**

--- a/google-oauth-client-java6/src/main/java/com/google/api/client/extensions/java6/auth/oauth2/AuthorizationCodeInstalledApp.java
+++ b/google-oauth-client-java6/src/main/java/com/google/api/client/extensions/java6/auth/oauth2/AuthorizationCodeInstalledApp.java
@@ -40,6 +40,30 @@ import java.util.logging.Logger;
  */
 public class AuthorizationCodeInstalledApp {
 
+
+  /**
+   *
+   * Helper interface to allow caller to browse.
+   *
+   */
+  public static interface Browser {
+    public void browse(String url) throws Exception;
+  }
+
+  /**
+   *
+   * Default browser that just throws an exception.
+   *
+   */
+  public static class FailingBrowser implements Browser {
+
+    /** Browse. */
+    public void browse(String url) throws Exception {
+      throw new Exception("Fail");
+    }
+
+  }
+
   /** Authorization code flow. */
   private final AuthorizationCodeFlow flow;
 
@@ -49,14 +73,26 @@ public class AuthorizationCodeInstalledApp {
   private static final Logger LOGGER =
       Logger.getLogger(AuthorizationCodeInstalledApp.class.getName());
 
+  private final Browser browser;
+
   /**
    * @param flow authorization code flow
    * @param receiver verification code receiver
    */
   public AuthorizationCodeInstalledApp(
       AuthorizationCodeFlow flow, VerificationCodeReceiver receiver) {
+    this(flow, receiver,  new FailingBrowser());
+  }
+
+  /**
+   * @param flow authorization code flow
+   * @param receiver verification code receiver
+   */
+  public AuthorizationCodeInstalledApp(
+      AuthorizationCodeFlow flow, VerificationCodeReceiver receiver, Browser browser) {
     this.flow = Preconditions.checkNotNull(flow);
     this.receiver = Preconditions.checkNotNull(receiver);
+    this.browser = browser;
   }
 
   /**
@@ -69,8 +105,8 @@ public class AuthorizationCodeInstalledApp {
     try {
       Credential credential = flow.loadCredential(userId);
       if (credential != null
-          && (credential.getRefreshToken() != null || 
-              credential.getExpiresInSeconds() == null || 
+          && (credential.getRefreshToken() != null ||
+              credential.getExpiresInSeconds() == null ||
               credential.getExpiresInSeconds() > 60)) {
         return credential;
       }
@@ -110,7 +146,15 @@ public class AuthorizationCodeInstalledApp {
    * @throws IOException I/O exception
    */
   protected void onAuthorization(AuthorizationCodeRequestUrl authorizationUrl) throws IOException {
-    browse(authorizationUrl.build());
+    String url = authorizationUrl.build();
+    Preconditions.checkNotNull(url);
+    System.out.println("Please open the following address in your browser:");
+    System.out.println("  " + url);
+    try {
+      browser.browse(url);
+    } catch (Exception e) {
+      LOGGER.log(Level.WARNING, "Unable to open browser", e);
+    }
   }
 
   /**

--- a/google-oauth-client-java6/src/main/java/com/google/api/client/extensions/java6/auth/oauth2/AuthorizationCodeInstalledApp.java
+++ b/google-oauth-client-java6/src/main/java/com/google/api/client/extensions/java6/auth/oauth2/AuthorizationCodeInstalledApp.java
@@ -37,6 +37,7 @@ import java.util.logging.Logger;
  *
  * @since 1.11
  * @author Yaniv Inbar
+ * @author Philipp Hanslovsky
  */
 public class AuthorizationCodeInstalledApp {
 
@@ -47,19 +48,24 @@ public class AuthorizationCodeInstalledApp {
    *
    */
   public static interface Browser {
+    /**
+     *
+     * @param url url to browse
+     * @throws Exception
+     */
     public void browse(String url) throws Exception;
   }
 
   /**
    *
-   * Default browser that just throws an exception.
+   * Default browser that just delegates to
+   * {@link AuthorizationCodeInstalledApp#browse(String)}.
    *
    */
-  public static class FailingBrowser implements Browser {
+  public static class DefaultBrowser implements Browser{
 
-    /** Browse. */
     public void browse(String url) throws Exception {
-      throw new Exception("Fail");
+      AuthorizationCodeInstalledApp.browse(url);
     }
 
   }
@@ -81,7 +87,7 @@ public class AuthorizationCodeInstalledApp {
    */
   public AuthorizationCodeInstalledApp(
       AuthorizationCodeFlow flow, VerificationCodeReceiver receiver) {
-    this(flow, receiver,  new FailingBrowser());
+    this(flow, receiver,  new DefaultBrowser());
   }
 
   /**


### PR DESCRIPTION
As outlined in #175 it is desirable in some cases to not use the `java.awt.Desktop` to browse the `authorizationUrl` in `AuthorizationCodeInstalledApp`, e.g. when running a `JavaFX` UI. For that purpose, I created a `Browser` interface with a single `browse(String)` method that is passed as an argument to `AuthorizationCodeInstalledApp`. In order not to introduce any breaking changes, there is also a `DefaultBrowser` that simply delegates to `AuthorizationCodeInstalledApp.browse`.

Fixes #175 

Note: `mvn findbugs:check` fails but it also fails on the `dev` branch.