### PR TITLE
Fix lint warning during import

### DIFF
--- a/google-oauth-client-java6/src/main/java/com/google/api/client/extensions/java6/auth/oauth2/AuthorizationCodeInstalledApp.java
+++ b/google-oauth-client-java6/src/main/java/com/google/api/client/extensions/java6/auth/oauth2/AuthorizationCodeInstalledApp.java
@@ -64,6 +64,7 @@ public class AuthorizationCodeInstalledApp {
    */
   public static class DefaultBrowser implements Browser{
 
+    @Override
     public void browse(String url) throws IOException {
       AuthorizationCodeInstalledApp.browse(url);
     }


### PR DESCRIPTION
Add @Override for browse implementation.

Prior to Java 1.6, this was not allowed, however, we now only support
Java 1.6+.